### PR TITLE
Add Base App metadata

### DIFF
--- a/docs/FARCASTER_MINIAPP_INTEGRATION.md
+++ b/docs/FARCASTER_MINIAPP_INTEGRATION.md
@@ -93,6 +93,14 @@ You can customize the mini app appearance by:
 2. Updating the splash icon in `/api/splash-icon/route.tsx`
 3. Changing colors and text in the embed configuration
 
+### 5. Add Base App Metadata
+
+Base App extends the Farcaster manifest with extra fields to improve discovery.
+Add `screenshotUrls`, `primaryCategory`, `tags`, `heroImageUrl`, `tagline`,
+`ogTitle`, `ogDescription`, and `ogImageUrl` to `/public/.well-known/farcaster.json`.
+See [Base docs](https://docs.base.org/base-app/introduction/mini-apps) for details.
+
+
 ## Testing
 
 To test your mini app integration:

--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -13,6 +13,22 @@
     "buttonTitle": "🧹 Sweep Wallet",
     "splashImageUrl": "https://wallet-sweep.vercel.app/api/splash-icon",
     "splashBackgroundColor": "#1a1a1a",
-    "webhookUrl": "https://wallet-sweep.vercel.app/api/webhook"
+    "webhookUrl": "https://wallet-sweep.vercel.app/api/webhook",
+    "screenshotUrls": [
+      "https://wallet-sweep.vercel.app/screenshot1.png"
+    ],
+    "primaryCategory": "finance",
+    "tags": [
+      "wallet",
+      "sweep",
+      "tokens",
+      "sell",
+      "batch"
+    ],
+    "heroImageUrl": "https://wallet-sweep.vercel.app/api/og",
+    "tagline": "Batch sell tokens easily",
+    "ogTitle": "Wallet Sweep",
+    "ogDescription": "Batch sell tokens from your wallet on Base",
+    "ogImageUrl": "https://wallet-sweep.vercel.app/api/og"
   }
 }


### PR DESCRIPTION
## Summary
- extend farcaster.json with Base App metadata fields like screenshotUrls, category, tags and more
- document new metadata fields required by Base App

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688675b8769c8331b5bbc8dcae99bcd8